### PR TITLE
add object wrapper to /models response

### DIFF
--- a/controllers/default_controller.py
+++ b/controllers/default_controller.py
@@ -113,9 +113,7 @@ def get_training_models() -> str:
         dict([(k, m[k]) for k in ["_id", "name", "urls", "status"]])
         for m in models
     ]
-
     ret = {'models': ms}
-
     return jsonify(ret)
 
 

--- a/controllers/default_controller.py
+++ b/controllers/default_controller.py
@@ -114,7 +114,9 @@ def get_training_models() -> str:
         for m in models
     ]
 
-    return jsonify(ms)
+    ret = {'models': ms}
+
+    return jsonify(ret)
 
 
 def create_query(newQuery) -> str:


### PR DESCRIPTION
This changes the way that the models response is returned from being a
list to an object with a key of "models", with its value being the list.
