### PR TITLE
add object wrapper to /queries response

### DIFF
--- a/controllers/default_controller.py
+++ b/controllers/default_controller.py
@@ -142,8 +142,9 @@ def find_query(id) -> str:
 
 
 def get_queries() -> str:
-    queries = query_collection().find()
-    return jsonify(queries)
+    queries = [q for q in query_collection().find()]
+    ret = {'queries': queries}
+    return jsonify(ret)
 
 
 def get_server_info() -> str:


### PR DESCRIPTION
This changes the response for the queries request to be an object that
wraps the underlying list, with a key of "queries" on the list value.
This also creates a list eval around the database call to prevent
erroneous return values.
