### PR TITLE
Include model name in queries

### DIFF
--- a/controllers/default_controller.py
+++ b/controllers/default_controller.py
@@ -128,6 +128,13 @@ def get_training_models() -> str:
 def sanitize_query(q):
     result = dict([(k, v) for (k, v) in q.items()])
     result["id"] = result.pop("_id")
+
+    if not "modelName" in result:
+        result["modelName"] = "UNKNOWN"
+
+    if not "model" in result:
+        result["model"] = "UNKNOWN"
+
     return result
 
 
@@ -152,7 +159,10 @@ def create_query(newQuery) -> str:
         qid = uuid4()
         try:
             syns = w2v.findSynonyms(word, 5)
-            q = {"_id": qid, "word": word, "results": syns}
+            q = {
+                "_id": qid, "word": word, "results": syns,
+                 "modelName": model["name"], "model": mid
+            }
             (query_collection()).insert_one(q)
             route = ".controllers_default_controller_find_query"
             location = url_for(route, id=str(qid))

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -195,6 +195,7 @@ paths:
                 id: "214b0c0c-8d1c-4782-b590-512a915251b9"
                 word: "darcy"
                 model: "0ebf527c-9c54-43f3-89b5-abbc89b2f43b"
+                modelName: "austen"
                 results:
                 - word: "collins"
                   quality: 0.9056707521507696423412880903924815356731414794921875
@@ -233,6 +234,7 @@ paths:
                 id: "214b0c0c-8d1c-4782-b590-512a915251b9"
                 word: "darcy"
                 model: "0ebf527c-9c54-43f3-89b5-abbc89b2f43b"
+                modelName: "austen"
                 results:
                 - word: "collins"
                   quality: 0.9056707521507696423412880903924815356731414794921875


### PR DESCRIPTION
Note:  unfortunately, there is no way to provide this functionality for queries generated with older versions of the controller since we didn't store the generating model ID in the database.  This commit also stores the generating model ID in the database but does not yet expose it in the API.
