### PR TITLE
add upgraded setuptools to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ADD . /opt/ophicleide
 WORKDIR /opt/ophicleide
 
 RUN yum install -y python-pip \
+ && pip install setuptools==36.2.5 \
  && pip install -r requirements.txt \
  && pip wheel -r wheel-requirements.txt -w . \
  && mv pymongo*.whl pymongo.zip


### PR DESCRIPTION
A change in the installations of the upstream connexion project in
conjunction with an older version of setuptools in the openshift-spark
image is causing build issues for the ophicleide-trainer. This patch
will make sure that setuptools gets upgraded, it is being added in the
Dockerfile as it is needs to be in place before the pip installation for
the requirements.