### PR TITLE
change dockerfile to update pip through easy_install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD . /opt/ophicleide
 
 WORKDIR /opt/ophicleide
 
-RUN yum install -y python-pip \
+RUN easy_install pip \
  && pip install setuptools==36.2.5 \
  && pip install -r requirements.txt \
  && pip wheel -r wheel-requirements.txt -w . \


### PR DESCRIPTION
it appears that the python-pip package has disappeared from the centos
7.4 yum repositories. this change adapts the pip install to use the
setuptools easy_install methodology.